### PR TITLE
switch from contrib postgres JSONField to native JSONField

### DIFF
--- a/translatable_fields/models.py
+++ b/translatable_fields/models.py
@@ -1,4 +1,4 @@
-from django.contrib.postgres.fields import JSONField
+from django.db.models import JSONField
 
 from translatable_fields.value import TranslatableValue
 


### PR DESCRIPTION
As of Django 3.1, the django.contrib.postgres.fields.JSONField has been deprecated in favor of django.db.models.JSONField .
The former will be removed in Django 4.0. This change prepares for that eventuality.
