### PR TITLE
encode and decode json so JSONField is happy

### DIFF
--- a/translatable_fields/models.py
+++ b/translatable_fields/models.py
@@ -1,4 +1,5 @@
-from django.contrib.postgres.fields import JSONField
+import json
+from django.db.models import JSONField
 
 from translatable_fields.value import TranslatableValue
 
@@ -9,7 +10,7 @@ class TranslatableField(JSONField):
             return value
 
         instance = TranslatableValue()
-        instance.update(value)
+        instance.update(json.loads(value))
 
         return instance
 

--- a/translatable_fields/widgets.py
+++ b/translatable_fields/widgets.py
@@ -63,7 +63,7 @@ class TranslatableWidget(forms.MultiWidget):
         ])
         if all(map(lambda x: x == '', result.values())):
             return ''
-        return result
+        return json.dumps(result)
 
     def get_context(self, name, value, attrs):
         context = super(forms.MultiWidget, self).get_context(name, value, attrs)


### PR DESCRIPTION
The Django Admin needs a string interface, so json encoding/decoding has to be done here explicitly.
